### PR TITLE
fix: Remove Python specific checklist items

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,8 +11,6 @@
 - [ ] Each commit represents a single, coherent unit of work
 - [ ] My changes are covered by unit tests
 - [ ] Unit tests successfully run locally
-- [ ] I have formatted Python code with `black`
-- [ ] I have checked static type hinting with `mypy`
 - [ ] I have added/updated necessary documentation, if required
 - [ ] I have checked for and resolved any merge conflicts
 - [ ] I have performed a self-review of my code

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,8 +9,6 @@
 
 - [ ] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
 - [ ] Each commit represents a single, coherent unit of work
-- [ ] My changes are covered by unit tests
-- [ ] Unit tests successfully run locally
 - [ ] I have added/updated necessary documentation, if required
 - [ ] I have checked for and resolved any merge conflicts
 - [ ] I have performed a self-review of my code


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Removes Python-specific checklist items during PRs, as well as those that refer to unit testing. The latter will be removed until we add in some quality control.

## Issue link
<!-- Add the link to the related issue(s) -->
n/a

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [ ] I have added/updated necessary documentation, if required
- [ ] I have checked for and resolved any merge conflicts
- [ ] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
