### PR TITLE
feat: issue-232 Timestamp using sample counting

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ fi
 # Rebuild the module.
 mkdir build
 cd build
-cmake ..
+cmake .. -DENABLE_TESTING=ON
 make -j$(nproc)
 make install
 ldconfig

--- a/include/gnuradio/spectre/batched_file_sink.h
+++ b/include/gnuradio/spectre/batched_file_sink.h
@@ -10,6 +10,8 @@
 #include <gnuradio/spectre/api.h>
 #include <gnuradio/sync_block.h>
 
+#include <optional>
+
 namespace gr {
 namespace spectre {
 
@@ -48,17 +50,23 @@ public:
      * `<year>/<month>/<day>`). \param is_tagged If true, metadata from stream tags is
      * recorded. \param tag_key Key used to extract values from stream tags if `is_tagged`
      * is true. \param initial_tag_value Default value used if no tag is present for the
-     * first sample and `is_tagged` is true. 0 for not provided.
+     * first sample and `is_tagged` is true. 0 for not provided. \param start_time
+     * Override the start time of the first batch, which by default is the current system
+     * time at the first call to work.
      */
-    static sptr make(const std::string& dir = ".",
-                     const std::string& tag = "spectre",
-                     const std::string& input_type = "fc32",
-                     const float batch_size = 1.0,
-                     const float sample_rate = 32000,
-                     const bool group_by_date = false,
-                     const bool is_tagged = false,
-                     const std::string& tag_key = "freq",
-                     const float initial_tag_value = 0);
+    static sptr
+    make(const std::string& dir = ".",
+         const std::string& tag = "spectre",
+         const std::string& input_type = "fc32",
+         const float batch_size = 1.0,
+         const float sample_rate = 32000,
+         const bool group_by_date = false,
+         const bool is_tagged = false,
+         const std::string& tag_key = "freq",
+         const float initial_tag_value = 0,
+         const std::optional<
+             std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>>
+             start_time = std::nullopt);
 };
 
 } // namespace spectre

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -41,23 +41,21 @@ message(STATUS "Building for version: ${VERSION} / ${LIBVER}")
 ########################################################################
 # Build and register unit test
 ########################################################################
-include(GrTest)
+if(ENABLE_TESTING)
+    include(GrTest)
 
-# If your unit tests require special include paths, add them here
-#include_directories()
-# List all files that contain Boost.UTF unit tests here
-list(APPEND test_spectre_sources
-)
-# Anything we need to link to for the unit tests go here
-list(APPEND GR_TEST_TARGET_DEPS gnuradio-spectre)
-
-if(NOT test_spectre_sources)
-    MESSAGE(STATUS "No C++ unit tests... skipping")
-    return()
-endif(NOT test_spectre_sources)
-
-foreach(qa_file ${test_spectre_sources})
-    GR_ADD_CPP_TEST("spectre_${qa_file}"
-        ${CMAKE_CURRENT_SOURCE_DIR}/${qa_file}
+    # If your unit tests require special include paths, add them here
+    #include_directories()
+    # List all files that contain Boost.UTF unit tests here
+    list(APPEND test_spectre_sources
+        qa_batched_file_sink.cc
     )
-endforeach(qa_file)
+    # Anything we need to link to for the unit tests go here
+    list(APPEND GR_TEST_TARGET_DEPS gnuradio-spectre gnuradio-blocks)
+
+    foreach(qa_file ${test_spectre_sources})
+        GR_ADD_CPP_TEST("spectre_${qa_file}"
+            ${CMAKE_CURRENT_SOURCE_DIR}/${qa_file}
+        )
+    endforeach(qa_file)
+endif(ENABLE_TESTING)

--- a/lib/batched_file_sink_impl.cc
+++ b/lib/batched_file_sink_impl.cc
@@ -44,21 +44,30 @@ std::filesystem::path generate_file_path(const std::string& dir,
     return dir / std::filesystem::path(buffer.str());
 }
 
+std::chrono::nanoseconds get_elapsed_time(int nsamples, float sample_rate)
+{
+    double seconds = static_cast<double>(nsamples) / static_cast<double>(sample_rate);
+    return std::chrono::nanoseconds(static_cast<int64_t>(seconds * 1e9));
+}
+
 } // namespace
 
 namespace gr {
 namespace spectre {
 
 
-batched_file_sink::sptr batched_file_sink::make(const std::string& dir,
-                                                const std::string& tag,
-                                                const std::string& input_type,
-                                                const float batch_size,
-                                                const float sample_rate,
-                                                const bool group_by_date,
-                                                const bool is_tagged,
-                                                const std::string& tag_key,
-                                                const float initial_tag_value)
+batched_file_sink::sptr batched_file_sink::make(
+    const std::string& dir,
+    const std::string& tag,
+    const std::string& input_type,
+    const float batch_size,
+    const float sample_rate,
+    const bool group_by_date,
+    const bool is_tagged,
+    const std::string& tag_key,
+    const float initial_tag_value,
+    const std::optional<std::chrono::time_point<std::chrono::system_clock,
+                                                std::chrono::nanoseconds>> start_time)
 {
     return gnuradio::make_block_sptr<batched_file_sink_impl>(dir,
                                                              tag,
@@ -68,33 +77,40 @@ batched_file_sink::sptr batched_file_sink::make(const std::string& dir,
                                                              group_by_date,
                                                              is_tagged,
                                                              tag_key,
-                                                             initial_tag_value);
+                                                             initial_tag_value,
+                                                             start_time);
 };
 
 
-batched_file_sink_impl::batched_file_sink_impl(const std::string& dir,
-                                               const std::string& tag,
-                                               const std::string& input_type,
-                                               const float batch_size,
-                                               const float sample_rate,
-                                               const bool group_by_date,
-                                               const bool is_tagged,
-                                               const std::string& tag_key,
-                                               const float initial_tag_value)
+batched_file_sink_impl::batched_file_sink_impl(
+    const std::string& dir,
+    const std::string& tag,
+    const std::string& input_type,
+    const float batch_size,
+    const float sample_rate,
+    const bool group_by_date,
+    const bool is_tagged,
+    const std::string& tag_key,
+    const float initial_tag_value,
+    const std::optional<std::chrono::time_point<std::chrono::system_clock,
+                                                std::chrono::nanoseconds>> start_time)
     : gr::sync_block("batched_file_sink",
                      gr::io_signature::make(1, 1, get_sizeof_stream_item(input_type)),
                      gr::io_signature::make(0, 0, 0)),
       d_dir(dir),
       d_tag(tag),
       d_input_type(input_type),
+      d_sample_rate(sample_rate),
       d_sizeof_stream_item(get_sizeof_stream_item(input_type)),
       d_nsamples_per_batch(get_num_samples_per_batch(batch_size, sample_rate)),
       d_is_tagged(is_tagged),
       d_group_by_date(group_by_date),
       d_tag_key(pmt::string_to_symbol(tag_key)),
       d_initial_tag_value(initial_tag_value),
-      d_batch_time(batch_time{ std::tm{}, 0 }),
       d_buffer_state(buffer_state::EMPTY),
+      d_batch_time(batch_time{ std::tm{}, 0 }),
+      d_start_time(start_time),
+      d_nsamples(0),
       d_nbuffered_samples(0),
       d_data_buffer(std::vector<char>(d_nsamples_per_batch * d_sizeof_stream_item, 0)),
       d_fdata(nullptr),
@@ -111,13 +127,13 @@ batched_file_sink_impl::batched_file_sink_impl(const std::string& dir,
 
 batched_file_sink_impl::~batched_file_sink_impl() { close_fstreams(); }
 
-void batched_file_sink_impl::init()
+void batched_file_sink_impl::init(std::chrono::nanoseconds time_elapsed)
 {
-    set_batch_time();
-    
+    set_batch_time(time_elapsed);
+
     // If the fstreams are open, close them first.
     close_fstreams();
-    
+
     open_fstreams();
 
     if (d_is_tagged) {
@@ -132,20 +148,22 @@ void batched_file_sink_impl::flush()
     close_fstreams();
 }
 
-void batched_file_sink_impl::set_batch_time()
+void batched_file_sink_impl::set_batch_time(std::chrono::nanoseconds time_elapsed)
 {
-    using namespace std::chrono;
+    // Get the system time at the first call to work.
+    if (!d_start_time.has_value()) {
+        d_start_time = std::chrono::system_clock::now();
+    }
 
-    // Get the current system time.
-    time_point<system_clock, nanoseconds> now = system_clock::now();
-
-    // Convert this to UTC (to seconds precision).
-    std::time_t now_c = system_clock::to_time_t(now);
+    // Convert the start time UTC (to seconds precision).
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>
+        batch_time = *d_start_time + time_elapsed;
+    std::time_t now_c = std::chrono::system_clock::to_time_t(batch_time);
     std::tm* utc_now = std::gmtime(&now_c);
 
-    // Then, extract the millisecond component.
-    microseconds us =
-        duration_cast<microseconds>(now.time_since_epoch() - seconds(now_c));
+    // Then, extract the microsecond component.
+    std::chrono::microseconds us = std::chrono::duration_cast<std::chrono::microseconds>(
+        batch_time.time_since_epoch() - std::chrono::seconds(now_c));
 
     d_batch_time.utc_tm = *utc_now;
     d_batch_time.us = static_cast<int>(us.count());
@@ -207,6 +225,7 @@ void batched_file_sink_impl::flush_data_buffer()
 {
     // Always flush the entire buffer to file.
     d_fdata.write(d_data_buffer.data(), d_sizeof_stream_item * d_nsamples_per_batch);
+    d_nsamples += d_nbuffered_samples;
     d_nbuffered_samples = 0;
 }
 
@@ -321,7 +340,7 @@ int batched_file_sink_impl::work(int noutput_items,
 
     // If the data buffer is empty, initialise a new batch.
     if (d_buffer_state == buffer_state::EMPTY) {
-        init();
+        init(get_elapsed_time(d_nsamples, d_sample_rate));
         d_buffer_state = buffer_state::FILLING;
     }
 

--- a/lib/batched_file_sink_impl.h
+++ b/lib/batched_file_sink_impl.h
@@ -31,15 +31,19 @@ enum buffer_state {
 class batched_file_sink_impl : public batched_file_sink
 {
 public:
-    batched_file_sink_impl(const std::string& dir,
-                           const std::string& tag,
-                           const std::string& input_type,
-                           const float batch_size,
-                           const float sample_rate,
-                           const bool group_by_date,
-                           const bool is_tagged,
-                           const std::string& tag_key,
-                           const float initial_tag_value);
+    batched_file_sink_impl(
+        const std::string& dir,
+        const std::string& tag,
+        const std::string& input_type,
+        const float batch_size,
+        const float sample_rate,
+        const bool group_by_date,
+        const bool is_tagged,
+        const std::string& tag_key,
+        const float initial_tag_value,
+        const std::optional<
+            std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>>
+            start_time);
     ~batched_file_sink_impl();
     int work(int noutput_items,
              gr_vector_const_void_star& in,
@@ -49,15 +53,21 @@ private:
     const std::string d_dir;
     const std::string d_tag;
     const std::string d_input_type;
+    const float d_sample_rate;
     const size_t d_sizeof_stream_item;
     const int d_nsamples_per_batch;
     const bool d_is_tagged;
     const bool d_group_by_date;
     const pmt::pmt_t d_tag_key;
     const float d_initial_tag_value;
-
-    batch_time d_batch_time;
     buffer_state d_buffer_state;
+
+    // Timestamp batches assuming a constant sample rate.
+    batch_time d_batch_time;
+    std::optional<
+        std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>>
+        d_start_time;
+    int d_nsamples;
 
     // Data buffer.
     int d_nbuffered_samples;
@@ -71,10 +81,10 @@ private:
     tag_t d_active_tag;
 
 
-    void init();
+    void init(std::chrono::nanoseconds time_elapsed);
     void flush();
 
-    void set_batch_time();
+    void set_batch_time(std::chrono::nanoseconds time_elapsed);
 
     void open_fstream(std::ofstream& f, const std::string& extension);
     void open_fstreams();

--- a/lib/qa_batched_file_sink.cc
+++ b/lib/qa_batched_file_sink.cc
@@ -1,0 +1,63 @@
+
+/*
+ * Copyright 2024-2026 Jimmy Fitzpatrick.
+ * This file is part of SPECTRE
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <gnuradio/blocks/vector_source.h>
+#include <gnuradio/spectre/batched_file_sink.h>
+#include <gnuradio/top_block.h>
+
+#include <boost/test/unit_test.hpp>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+
+/* Run a flowgraph that writes 20 complex float samples to disk in 4 batches, with the
+ * first sample timestamped at the Unix epoch. We then verify each file is timestamped
+   correctly and that we can recover the samples. */
+BOOST_AUTO_TEST_CASE(batched_file_sink_run)
+{
+    namespace fs = std::filesystem;
+
+    const fs::path tmpdir = fs::temp_directory_path() / "batched_file_sink";
+    fs::create_directories(tmpdir);
+
+    const int total_samples = 20;
+    auto source = gr::blocks::vector_source_c::make(
+        std::vector<gr_complex>(total_samples, { 1, 0 }));
+
+    auto sink = gr::spectre::batched_file_sink::make(
+        tmpdir,
+        /*tag=*/"foo",
+        /*input_type=*/"fc32",
+        /*batch_size=*/1.0f,
+        /*sample_rate=*/5.0f,
+        /*group_by_date=*/false,
+        /*is_tagged=*/false,
+        /*tag_key=*/"unused",
+        /*initial_tag_value=*/0.0f,
+        /*start_time=*/std::chrono::system_clock::from_time_t(0));
+
+    auto tb = gr::make_top_block("top");
+    tb->connect(source, 0, sink, 0);
+    tb->run();
+
+    std::vector<fs::path> paths = { tmpdir / "1970-01-01T00:00:00.000000Z_foo.fc32",
+                                    tmpdir / "1970-01-01T00:00:01.000000Z_foo.fc32",
+                                    tmpdir / "1970-01-01T00:00:02.000000Z_foo.fc32",
+                                    tmpdir / "1970-01-01T00:00:03.000000Z_foo.fc32" };
+    const int samples_per_batch = 5;
+    const std::vector<gr_complex> expected(samples_per_batch, { 1, 0 });
+    for (const auto& path : paths) {
+        BOOST_TEST(fs::exists(path));
+        std::ifstream f(path, std::ios::binary);
+        std::vector<gr_complex> buff(samples_per_batch, { 0, 0 });
+        f.read(reinterpret_cast<char*>(buff.data()),
+               samples_per_batch * sizeof(gr_complex));
+        BOOST_TEST(buff == expected);
+    }
+
+    fs::remove_all(tmpdir);
+}

--- a/python/spectre/bindings/batched_file_sink_python.cc
+++ b/python/spectre/bindings/batched_file_sink_python.cc
@@ -14,9 +14,10 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(batched_file_sink.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(974219b1eb7e27c7ac3cf6048eece7fc)                     */
+/* BINDTOOL_HEADER_FILE_HASH(87c949d662d56ac7b76cc759ab161186)                     */
 /***********************************************************************************/
 
+#include <pybind11/chrono.h>
 #include <pybind11/complex.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -46,6 +47,7 @@ void bind_batched_file_sink(py::module& m)
            py::arg("is_tagged") = false,
            py::arg("tag_key") = "freq",
            py::arg("initial_tag_value") = 0,
+           py::arg("start_time") = std::nullopt,
            D(batched_file_sink,make)
         )
         


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Instead of timestamping every batch based on the system time, do so for the first but for those thereafter infer it by counting samples. This eliminates the variance due to file I/O and thus addresses the vertical artefacts in spectrograms described in the linked issue.

I also added a QA flowgraph for `batched_file_sink` to cover the change.

## Issue link
<!-- Add the link to the related issue(s) -->
[issue-232](https://github.com/spectregrams/spectre/issues/232)

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
