### PR TITLE
fix: issue-236 Patch an overflow bug

### DIFF
--- a/lib/batched_file_sink_impl.cc
+++ b/lib/batched_file_sink_impl.cc
@@ -19,7 +19,7 @@ namespace {
 static constexpr int NUM_DIGITS_MICROSECONDS = 6;
 static constexpr int INPUT_PORT = 0;
 
-int get_num_samples_per_batch(const float batch_size, const float sample_rate)
+size_t get_num_samples_per_batch(const float batch_size, const float sample_rate)
 {
     // Naturally, we can't have a non-integral number of samples in a batch,
     // so we floor to ensure that the elapsed time per batch doesn't surpass the
@@ -44,7 +44,7 @@ std::filesystem::path generate_file_path(const std::string& dir,
     return dir / std::filesystem::path(buffer.str());
 }
 
-std::chrono::nanoseconds get_elapsed_time(int nsamples, float sample_rate)
+std::chrono::nanoseconds get_elapsed_time(size_t nsamples, float sample_rate)
 {
     double seconds = static_cast<double>(nsamples) / static_cast<double>(sample_rate);
     return std::chrono::nanoseconds(static_cast<int64_t>(seconds * 1e9));
@@ -212,8 +212,8 @@ int batched_file_sink_impl::fill_data_buffer(int noutput_items, const char* in)
     // Fill the buffer with as many samples as possible, without exceeding its fixed size.
     // Keep a record of how many we've consumed, so we can report back to gnuradio
     // runtime.
-    int nconsumed_items =
-        std::min(noutput_items, d_nsamples_per_batch - d_nbuffered_samples);
+    int nconsumed_items = std::min(static_cast<size_t>(noutput_items),
+                                   d_nsamples_per_batch - d_nbuffered_samples);
     std::memcpy(d_data_buffer.data() + d_nbuffered_samples * d_sizeof_stream_item,
                 in,
                 nconsumed_items * d_sizeof_stream_item);

--- a/lib/batched_file_sink_impl.h
+++ b/lib/batched_file_sink_impl.h
@@ -55,7 +55,7 @@ private:
     const std::string d_input_type;
     const float d_sample_rate;
     const size_t d_sizeof_stream_item;
-    const int d_nsamples_per_batch;
+    const size_t d_nsamples_per_batch;
     const bool d_is_tagged;
     const bool d_group_by_date;
     const pmt::pmt_t d_tag_key;
@@ -67,15 +67,15 @@ private:
     std::optional<
         std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>>
         d_start_time;
-    int d_nsamples;
+    size_t d_nsamples;
 
     // Data buffer.
-    int d_nbuffered_samples;
+    size_t d_nbuffered_samples;
     std::vector<char> d_data_buffer;
     std::ofstream d_fdata;
 
     // Tag buffer.
-    int d_nbuffered_tags;
+    size_t d_nbuffered_tags;
     std::vector<float> d_tags_buffer;
     std::ofstream d_ftags;
     tag_t d_active_tag;

--- a/lib/qa_batched_file_sink.cc
+++ b/lib/qa_batched_file_sink.cc
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(batched_file_sink_run)
     const fs::path tmpdir = fs::temp_directory_path() / "batched_file_sink";
     fs::create_directories(tmpdir);
 
-    const int total_samples = 20;
+    const size_t total_samples = 20;
     auto source = gr::blocks::vector_source_c::make(
         std::vector<gr_complex>(total_samples, { 1, 0 }));
 


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Patch an overflow bug observed while recording long-form spectrograms with the RX-888 MK II at an extreme sample rate (64 Msps). Since `d_nsamples` is an `int` whose max value on my machine is `2147483647`, it takes just over 30 seconds for `d_nsamples` to overflow. The [previous PR](https://github.com/spectregrams/gr-spectre/pull/22) introduced elapsed time being inferred through sample counting, so the undefined behavior after that duration resulted in dodgy timestamping of files at runtime.

On my machine the max size of `size_t` is `18446744073709551615`, which means at the same sample rate it would take 9000 years to overflow. Should be sorted!

## Issue link
<!-- Add the link to the related issue(s) -->
> [issue-236](https://github.com/spectregrams/spectre/issues/236)

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
