### PR TITLE
fix: issue-209 float32 overflow in tag sample count for long frequency sweeps

### DIFF
--- a/include/gnuradio/spectre/batched_file_sink.h
+++ b/include/gnuradio/spectre/batched_file_sink.h
@@ -30,8 +30,8 @@ namespace spectre {
  *
  *     <timestamp>_<tag>.hdr
  *
- * which interleaves the tag values and the number of samples corresponding to that
- * tag, recording both as single precision floats.
+ * which interleaves the tag values (each as float) and the number of samples
+ * corresponding to that tag (each as uint64_t).
  */
 class SPECTRE_API batched_file_sink : virtual public gr::sync_block
 {

--- a/lib/batched_file_sink_impl.cc
+++ b/lib/batched_file_sink_impl.cc
@@ -119,7 +119,7 @@ batched_file_sink_impl::batched_file_sink_impl(
       // tags (one per sample), but the actual number of tags per batch may vary due to
       // the nature of the GNU Radio runtime. So practically, it's unlikely this will ever
       // fill entirely.
-      d_tags_buffer(std::vector<float>(d_nsamples_per_batch * 2, 0)),
+      d_tags_buffer(std::vector<tag_entry>(d_nsamples_per_batch)),
       d_ftags(nullptr),
       d_active_tag()
 {
@@ -296,11 +296,10 @@ void batched_file_sink_impl::fill_tag_buffer(int nconsumed_items)
         // offset to the next tag.
         tag_t next_tag{ tags[n] };
         float tag_value = pmt::to_float(d_active_tag.value);
-        float num_samples = static_cast<float>(next_tag.offset - d_active_tag.offset);
+        uint64_t num_samples = next_tag.offset - d_active_tag.offset;
 
         // Record the tag value, along with the number of samples at that value.
-        d_tags_buffer[2 * d_nbuffered_tags] = tag_value;
-        d_tags_buffer[2 * d_nbuffered_tags + 1] = num_samples;
+        d_tags_buffer[d_nbuffered_tags] = {tag_value, num_samples};
         d_nbuffered_tags++;
 
         // Finally, update the active tag.
@@ -315,20 +314,20 @@ void batched_file_sink_impl::fill_tag_buffer(int nconsumed_items)
         // to that tag at the next call to work. But they'll be recorded in the next
         // batch.
         float tag_value = pmt::to_float(d_active_tag.value);
-        float num_samples_remaining = static_cast<float>(abs_end - d_active_tag.offset);
-        d_tags_buffer[2 * d_nbuffered_tags] = tag_value;
-        d_tags_buffer[2 * d_nbuffered_tags + 1] = num_samples_remaining;
+        uint64_t num_samples_remaining = abs_end - d_active_tag.offset;
+        d_tags_buffer[d_nbuffered_tags] = {tag_value, num_samples_remaining};
         d_nbuffered_tags++;
     }
 }
 
 void batched_file_sink_impl::flush_tag_buffer()
 {
-    const char* s = reinterpret_cast<const char*>(d_tags_buffer.data());
-    // Flush the tag buffer, avoiding garbage values. In contrast to the data buffer, it's
-    // (almost certainly) only partially filled.
-    size_t num_chars = 2 * d_nbuffered_tags * sizeof(float);
-    d_ftags.write(s, num_chars);
+    // Flush tag entries one by one to avoid struct padding in the binary file.
+    // Each entry is written as [value_float (4 bytes)][nsamples_uint64 (8 bytes)].
+    for (size_t i = 0; i < d_nbuffered_tags; i++) {
+        d_ftags.write(reinterpret_cast<const char*>(&d_tags_buffer[i].value),   sizeof(float));
+        d_ftags.write(reinterpret_cast<const char*>(&d_tags_buffer[i].nsamples), sizeof(uint64_t));
+    }
     d_nbuffered_tags = 0;
 };
 

--- a/lib/batched_file_sink_impl.cc
+++ b/lib/batched_file_sink_impl.cc
@@ -119,7 +119,7 @@ batched_file_sink_impl::batched_file_sink_impl(
       // tags (one per sample), but the actual number of tags per batch may vary due to
       // the nature of the GNU Radio runtime. So practically, it's unlikely this will ever
       // fill entirely.
-      d_tags_buffer(std::vector<tag_entry>(d_nsamples_per_batch)),
+      d_tags_buffer(std::vector<stream_tag>(d_nsamples_per_batch)),
       d_ftags(nullptr),
       d_active_tag()
 {
@@ -299,7 +299,7 @@ void batched_file_sink_impl::fill_tag_buffer(int nconsumed_items)
         uint64_t num_samples = next_tag.offset - d_active_tag.offset;
 
         // Record the tag value, along with the number of samples at that value.
-        d_tags_buffer[d_nbuffered_tags] = {tag_value, num_samples};
+        d_tags_buffer[d_nbuffered_tags] = { tag_value, num_samples };
         d_nbuffered_tags++;
 
         // Finally, update the active tag.
@@ -315,18 +315,20 @@ void batched_file_sink_impl::fill_tag_buffer(int nconsumed_items)
         // batch.
         float tag_value = pmt::to_float(d_active_tag.value);
         uint64_t num_samples_remaining = abs_end - d_active_tag.offset;
-        d_tags_buffer[d_nbuffered_tags] = {tag_value, num_samples_remaining};
+        d_tags_buffer[d_nbuffered_tags] = { tag_value, num_samples_remaining };
         d_nbuffered_tags++;
     }
 }
 
 void batched_file_sink_impl::flush_tag_buffer()
 {
-    // Flush tag entries one by one to avoid struct padding in the binary file.
-    // Each entry is written as [value_float (4 bytes)][nsamples_uint64 (8 bytes)].
+    // Flush tag entries one by one to avoid container padding in the binary file.
+    // The tag values are interleaved with the number of samples per tag.
     for (size_t i = 0; i < d_nbuffered_tags; i++) {
-        d_ftags.write(reinterpret_cast<const char*>(&d_tags_buffer[i].value),   sizeof(float));
-        d_ftags.write(reinterpret_cast<const char*>(&d_tags_buffer[i].nsamples), sizeof(uint64_t));
+        d_ftags.write(reinterpret_cast<const char*>(&d_tags_buffer[i].first),
+                      sizeof(stream_tag::first_type));
+        d_ftags.write(reinterpret_cast<const char*>(&d_tags_buffer[i].second),
+                      sizeof(stream_tag::second_type));
     }
     d_nbuffered_tags = 0;
 };

--- a/lib/batched_file_sink_impl.h
+++ b/lib/batched_file_sink_impl.h
@@ -9,11 +9,11 @@
 
 #include <gnuradio/spectre/batched_file_sink.h>
 
-#include <cstdint>
 #include <gnuradio/types.h>
 #include <filesystem>
 #include <fstream>
 #include <optional>
+#include <utility>
 
 namespace gr {
 namespace spectre {
@@ -23,10 +23,9 @@ struct batch_time {
     int us;
 };
 
-struct tag_entry {
-    float value;
-    uint64_t nsamples;
-};
+
+// Tag value (first) and the number of samples belonging to that tag (second).
+typedef std::pair<float, uint64_t> stream_tag;
 
 enum buffer_state {
     EMPTY = 0,
@@ -82,7 +81,7 @@ private:
 
     // Tag buffer.
     size_t d_nbuffered_tags;
-    std::vector<tag_entry> d_tags_buffer;
+    std::vector<stream_tag> d_tags_buffer;
     std::ofstream d_ftags;
     tag_t d_active_tag;
 

--- a/lib/batched_file_sink_impl.h
+++ b/lib/batched_file_sink_impl.h
@@ -9,6 +9,7 @@
 
 #include <gnuradio/spectre/batched_file_sink.h>
 
+#include <cstdint>
 #include <gnuradio/types.h>
 #include <filesystem>
 #include <fstream>
@@ -20,6 +21,11 @@ namespace spectre {
 struct batch_time {
     std::tm utc_tm;
     int us;
+};
+
+struct tag_entry {
+    float value;
+    uint64_t nsamples;
 };
 
 enum buffer_state {
@@ -76,7 +82,7 @@ private:
 
     // Tag buffer.
     size_t d_nbuffered_tags;
-    std::vector<float> d_tags_buffer;
+    std::vector<tag_entry> d_tags_buffer;
     std::ofstream d_ftags;
     tag_t d_active_tag;
 

--- a/lib/qa_batched_file_sink.cc
+++ b/lib/qa_batched_file_sink.cc
@@ -7,21 +7,47 @@
 
 #include <gnuradio/blocks/vector_source.h>
 #include <gnuradio/spectre/batched_file_sink.h>
+#include <gnuradio/tags.h>
 #include <gnuradio/top_block.h>
+#include <pmt/pmt.h>
 
 #include <boost/test/unit_test.hpp>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <utility>
 
-/* Run a flowgraph that writes 20 complex float samples to disk in 4 batches, with the
- * first sample timestamped at the Unix epoch. We then verify each file is timestamped
-   correctly and that we can recover the samples. */
+namespace {
+gr::tag_t
+make_frequency_tag(const uint64_t offset, const std::string& key, const double value)
+{
+    gr::tag_t tag;
+    tag.offset = offset;
+    tag.key = pmt::string_to_symbol(key);
+    tag.value = pmt::from_double(value);
+    return tag;
+}
+} // namespace
+
+/* Run a flowgraph that writes 20 complex floats (without stream tags) to disk in 4
+ * batches, with the first sample timestamped at the Unix epoch:
+ *
+ * offset:  0     1     2     ... 19
+ * sample:  1+0i  1+0i  1+0i  ... 1+0i
+ *
+ * We then verify each file is timestamped correctly and that we can recover the samples.
+ *
+ * Expected output:
+ *   1970-01-01T00:00:00Z000000_foo.fc32  -- samples 0..4
+ *   1970-01-01T00:00:01Z000000_foo.fc32  -- samples 5..9
+ *   1970-01-01T00:00:02Z000000_foo.fc32  -- samples 10..14
+ *   1970-01-01T00:00:03Z000000_foo.fc32  -- samples 15..19
+ */
 BOOST_AUTO_TEST_CASE(batched_file_sink_run)
 {
     namespace fs = std::filesystem;
 
-    const fs::path tmpdir = fs::temp_directory_path() / "batched_file_sink";
+    const fs::path tmpdir = fs::temp_directory_path() / "batched_file_sink_run";
     fs::create_directories(tmpdir);
 
     const size_t total_samples = 20;
@@ -48,16 +74,108 @@ BOOST_AUTO_TEST_CASE(batched_file_sink_run)
                                     tmpdir / "1970-01-01T00:00:01.000000Z_foo.fc32",
                                     tmpdir / "1970-01-01T00:00:02.000000Z_foo.fc32",
                                     tmpdir / "1970-01-01T00:00:03.000000Z_foo.fc32" };
-    const int samples_per_batch = 5;
-    const std::vector<gr_complex> expected(samples_per_batch, { 1, 0 });
+    const int num_samples_per_batch = 5;
+    const std::vector<gr_complex> expected(num_samples_per_batch, { 1, 0 });
     for (const auto& path : paths) {
         BOOST_TEST(fs::exists(path));
         std::ifstream f(path, std::ios::binary);
-        std::vector<gr_complex> buff(samples_per_batch, { 0, 0 });
+        std::vector<gr_complex> buff(num_samples_per_batch, { 0, 0 });
         f.read(reinterpret_cast<char*>(buff.data()),
-               samples_per_batch * sizeof(gr_complex));
+               num_samples_per_batch * sizeof(gr_complex));
         BOOST_TEST(buff == expected);
     }
+
+    fs::remove_all(tmpdir);
+}
+
+/**
+ * Run a flowgraph which writes 10 complex floats (with stream tags) to disk in 2
+ * batches, with the first sample timestamped at the Unix epoch:
+ *
+ * Stream:
+ * offset:  0     1     2     3     4     5     6     7     8     9
+ * sample:  1+0i  1+0i  1+0i  1+0i  1+0i  1+0i  1+0i  1+0i  1+0i  1+0i
+ * tags:    f0    f1          f2                  f3          f4
+ *
+ * We then verify each file is timestamped correctly and that we can recover the samples
+ * and stream tags.
+ *
+ * Expected output:
+ *   1970-01-01T00:00:00Z000000_foo.fc32  -- samples 0..4
+ *   1970-01-01T00:00:00Z000000_foo.hdr   -- (f0, 1), (f1, 2), (f2, 2)
+ *   1970-01-01T00:00:01Z000000_foo.fc32  -- samples 5..9
+ *   1970-01-01T00:00:01Z000000_foo.hdr   -- (f2, 1), (f3, 2), (f4, 2)
+ */
+BOOST_AUTO_TEST_CASE(batched_file_sink_stream_tags)
+{
+    namespace fs = std::filesystem;
+    typedef std::pair<float, uint64_t> stream_tag;
+
+    const fs::path tmpdir = fs::temp_directory_path() / "batched_file_sink_stream_tags";
+    fs::create_directories(tmpdir);
+
+    const std::string tag_key = "freq";
+    const size_t total_samples = 10;
+    std::vector<gr::tag_t> tags = { make_frequency_tag(0, tag_key, 90e6),
+                                    make_frequency_tag(1, tag_key, 95e6),
+                                    make_frequency_tag(3, tag_key, 100e6),
+                                    make_frequency_tag(6, tag_key, 105e6),
+                                    make_frequency_tag(8, tag_key, 110e6) };
+    std::vector<gr_complex> input(total_samples, { 1, 0 });
+    auto source =
+        gr::blocks::vector_source_c::make(input, /*repeat=*/false, /*vlen=*/1, tags);
+
+    auto sink = gr::spectre::batched_file_sink::make(
+        /*dir=*/tmpdir,
+        /*tag=*/"foo",
+        /*input_type=*/"fc32",
+        /*batch_size=*/1.0f,
+        /*sample_rate=*/5.0f,
+        /*group_by_date=*/false,
+        /*is_tagged=*/true,
+        /*tag_key=*/tag_key,
+        /*initial_tag_value=*/0.0f,
+        /*start_time=*/std::chrono::system_clock::from_time_t(0));
+
+    auto tb = gr::make_top_block("top");
+    tb->connect(source, 0, sink, 0);
+    tb->run();
+
+    std::vector<fs::path> data_paths = { tmpdir / "1970-01-01T00:00:00.000000Z_foo.fc32",
+                                         tmpdir /
+                                             "1970-01-01T00:00:01.000000Z_foo.fc32" };
+    const int num_samples_per_batch = 5;
+    const std::vector<gr_complex> expected_data(num_samples_per_batch, gr_complex(1, 0));
+
+    for (const fs::path& path : data_paths) {
+        BOOST_TEST(fs::exists(path));
+        std::ifstream f(path, std::ios::binary);
+        std::vector<gr_complex> got_data(num_samples_per_batch);
+        f.read(reinterpret_cast<char*>(got_data.data()),
+               sizeof(gr_complex) * num_samples_per_batch);
+        BOOST_TEST(expected_data == got_data);
+    }
+
+    std::vector<fs::path> hdr_paths = { tmpdir / "1970-01-01T00:00:00.000000Z_foo.hdr",
+                                        tmpdir / "1970-01-01T00:00:01.000000Z_foo.hdr" };
+    const int num_tags_per_batch = 3;
+    const std::vector<stream_tag> expected_tags = {
+        stream_tag(90e6, 1),  stream_tag(95e6, 2),  stream_tag(100e6, 2),
+        stream_tag(100e6, 1), stream_tag(105e6, 2), stream_tag(110e6, 2)
+    };
+    std::vector<stream_tag> got_tags;
+    got_tags.reserve(hdr_paths.size() * num_tags_per_batch);
+    for (const fs::path& path : hdr_paths) {
+        BOOST_TEST(fs::exists(path));
+        std::ifstream f(path, std::ios::binary);
+        stream_tag tag;
+        for (size_t n = 0; n < num_tags_per_batch; n++) {
+            f.read(reinterpret_cast<char*>(&tag.first), sizeof(stream_tag::first_type));
+            f.read(reinterpret_cast<char*>(&tag.second), sizeof(stream_tag::second_type));
+            got_tags.push_back(tag);
+        }
+    }
+    BOOST_TEST(expected_tags == got_tags);
 
     fs::remove_all(tmpdir);
 }

--- a/python/spectre/bindings/batched_file_sink_python.cc
+++ b/python/spectre/bindings/batched_file_sink_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(batched_file_sink.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(87c949d662d56ac7b76cc759ab161186)                     */
+/* BINDTOOL_HEADER_FILE_HASH(8b59dddcd3970778cfd9edb941ad8ed2)                     */
 /***********************************************************************************/
 
 #include <pybind11/chrono.h>


### PR DESCRIPTION
## What does this PR do?

The batched file sink stored the number of samples per tag as `float`, which overflows at ~16M samples (max integer representable by float32). This causes undefined behaviour in long frequency sweeps.

Replaces the interleaved `vector<float>` tag buffer with a `tag_entry` struct storing the tag value as `float` and the sample count as `uint64_t`. The flush method writes each field separately to avoid struct padding in the binary file.

## Issue link

https://github.com/spectregrams/spectre/issues/209

## Checklist before merging

- [ ] My commit history follows the conventional commits specification
- [x] Each commit represents a single, coherent unit of work
- [ ] I have added/updated necessary documentation, if required
- [x] I have checked for and resolved any merge conflicts
- [x] I have performed a self-review of my code

## Additional notes

Companion to spectregrams/spectre#242 which updates the Python reader for the new binary format. Build verified with GNU Radio 3.10.12 and cmake (100% clean, no errors or warnings). The struct uses natural layout (float at offset 0, uint64 at offset 4 or 8 depending on platform alignment), but the flush writes each field individually to produce a portable 12-byte binary format regardless of padding.